### PR TITLE
feature: retry [delayed] content

### DIFF
--- a/frontend/deployment.yaml
+++ b/frontend/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hackernews
+  namespace: hackernews
   labels:
     app.kubernetes.io/name: hackernews
 spec:
@@ -15,7 +16,7 @@ spec:
     spec:
       containers:
       - name: hackernews
-        image: trieve/hn-ui:5
+        image: trieve/hn-ui:6
         ports:
           - containerPort: 80
         env:
@@ -30,6 +31,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: hackernews
+  namespace: hackernews
   labels:
     app.kubernetes.io/name: hackernews
 spec:
@@ -46,6 +48,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-hackernews
+  namespace: hackernews
   annotations:
     kubernetes.io/ingress.class: gce
     external-dns.alpha.kubernetes.io/hostname: "hn.withtrieve.com"

--- a/hackernews-ingest/get_dataset/get-datasets.yaml
+++ b/hackernews-ingest/get_dataset/get-datasets.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: get-datasets
-  namespace: 
+  namespace: hackernews
   labels:
     app.kubernetes.io/name: get-datasets
 spec:

--- a/hackernews-ingest/get_dataset/get_dataset.py
+++ b/hackernews-ingest/get_dataset/get_dataset.py
@@ -8,7 +8,7 @@ redis_client = redis.Redis(
 )
 
 while True:
-    start = redis_client.blpop("tovisit")
+    start = redis_client.brpop("tovisit")
     start = int(start[1])
     fail = False
     try:
@@ -20,4 +20,8 @@ while True:
     print(item)
     if (not fail and (item is not None) and ("deleted" not in item) and ("dead" not in item)):
         print(start)
-        redis_client.lpush("hn", str(item))
+        if ("text" in item) and item["text"] == "[delayed]":
+            # Add this back in the queue, as the text is not ready to be parsed
+            redis_client.lpush("tovisit", str(start))
+        else: 
+            redis_client.lpush("hn", str(item))

--- a/hackernews-ingest/set-ids/set-ids.yaml
+++ b/hackernews-ingest/set-ids/set-ids.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: set-ids
-  namespace: 
+  namespace: hackernews
   labels:
     app.kubernetes.io/name: set-ids
 spec:


### PR DESCRIPTION
We had some issues with content being marked as [delayed] in text. Seems like an undocumented part of the hackernews api if you query it new items too fast it won't return the actual content. Push items back into the `tovisit` queue if the content is `[delayed]`
