### PR TITLE
feature: add refresh to recommended queries along with search types

### DIFF
--- a/frontend/src/components/search/Search.tsx
+++ b/frontend/src/components/search/Search.tsx
@@ -1,4 +1,4 @@
-import { FiExternalLink } from "solid-icons/fi";
+import { FiExternalLink, FiRefreshCw } from "solid-icons/fi";
 import {
   HiOutlineAdjustmentsVertical,
   HiSolidMagnifyingGlass,
@@ -17,6 +17,7 @@ export interface SearchProps {
   setQuery: Setter<string>;
   suggestedQueries: Accessor<string[]>;
   loadingSuggestedQueries: Accessor<boolean>;
+  getSuggestedQueries: () => void;
   algoliaLink: Accessor<string>;
   setOpenRateQueryModal: Setter<boolean>;
   aiEnabled: Accessor<boolean>;
@@ -172,6 +173,13 @@ export const Search = (props: SearchProps) => {
           </a>
         </div>
         <div class="mx-2 flex flex-wrap items-center gap-2">
+          <button
+            class="border border-stone-300 bg-hn p-1 text-zinc-600 hover:border-stone-900 hover:text-zinc-900"
+            onClick={() => props.getSuggestedQueries()}
+            disabled={props.loadingSuggestedQueries()}
+          >
+            <FiRefreshCw class="h-2 w-2" />
+          </button>
           <p class="text-sm text-zinc-600">Suggested queries: </p>
           <Show
             when={props.suggestedQueries().length > 0}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -13,34 +13,34 @@ const root = document.getElementById("root");
 
 render(
   () => (
-    <section class="bg-white dark:bg-gray-900">
-      <div class="mx-auto max-w-screen-md px-4 py-8 text-center lg:px-12 lg:py-16">
-        <svg
-          class="mx-auto mb-4 h-10 w-10 text-[#ff6600]"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 512 512"
-        >
-          <path
-            fill="currentColor"
-            d="M331.8 224.1c28.29 0 54.88 10.99 74.86 30.97l19.59 19.59c40.01-17.74 71.25-53.3 81.62-96.65c5.725-23.92 5.34-47.08 .2148-68.4c-2.613-10.88-16.43-14.51-24.34-6.604l-68.9 68.9h-75.6V97.2l68.9-68.9c7.912-7.912 4.275-21.73-6.604-24.34c-21.32-5.125-44.48-5.51-68.4 .2148c-55.3 13.23-98.39 60.22-107.2 116.4C224.5 128.9 224.2 137 224.3 145l82.78 82.86C315.2 225.1 323.5 224.1 331.8 224.1zM384 278.6c-23.16-23.16-57.57-27.57-85.39-13.9L191.1 158L191.1 95.99l-127.1-95.99L0 63.1l96 127.1l62.04 .0077l106.7 106.6c-13.67 27.82-9.251 62.23 13.91 85.39l117 117.1c14.62 14.5 38.21 14.5 52.71-.0016l52.75-52.75c14.5-14.5 14.5-38.08-.0016-52.71L384 278.6zM227.9 307L168.7 247.9l-148.9 148.9c-26.37 26.37-26.37 69.08 0 95.45C32.96 505.4 50.21 512 67.5 512s34.54-6.592 47.72-19.78l119.1-119.1C225.5 352.3 222.6 329.4 227.9 307zM64 472c-13.25 0-24-10.75-24-24c0-13.26 10.75-24 24-24S88 434.7 88 448C88 461.3 77.25 472 64 472z"
-          />
-        </svg>
-        <h1 class="mb-4 text-4xl font-bold leading-none tracking-tight text-gray-900 dark:text-white md:text-5xl lg:mb-6 xl:text-6xl">
-          Under Maintenance
-        </h1>
-        <p class="font-light text-gray-500 dark:text-gray-400 md:text-lg xl:text-xl">
-          Will be back up soon!
-        </p>
-      </div>
-    </section>
-    // <Router>
-    //   <Route path="/analytics" component={AnalyticsPage} />
-    //   <Route path="/chat" component={RagPage} />
-    //   <Route path="/about" component={AboutPage} />
-    //   <Route path="/help" component={HelpPage} />
-    //   <Route path="/" component={SearchPage} />
-    //   <Route path="*404" component={RedirectToSearch} />
-    // </Router>
+    // <section class="bg-white dark:bg-gray-900">
+    //   <div class="mx-auto max-w-screen-md px-4 py-8 text-center lg:px-12 lg:py-16">
+    //     <svg
+    //       class="mx-auto mb-4 h-10 w-10 text-[#ff6600]"
+    //       xmlns="http://www.w3.org/2000/svg"
+    //       viewBox="0 0 512 512"
+    //     >
+    //       <path
+    //         fill="currentColor"
+    //         d="M331.8 224.1c28.29 0 54.88 10.99 74.86 30.97l19.59 19.59c40.01-17.74 71.25-53.3 81.62-96.65c5.725-23.92 5.34-47.08 .2148-68.4c-2.613-10.88-16.43-14.51-24.34-6.604l-68.9 68.9h-75.6V97.2l68.9-68.9c7.912-7.912 4.275-21.73-6.604-24.34c-21.32-5.125-44.48-5.51-68.4 .2148c-55.3 13.23-98.39 60.22-107.2 116.4C224.5 128.9 224.2 137 224.3 145l82.78 82.86C315.2 225.1 323.5 224.1 331.8 224.1zM384 278.6c-23.16-23.16-57.57-27.57-85.39-13.9L191.1 158L191.1 95.99l-127.1-95.99L0 63.1l96 127.1l62.04 .0077l106.7 106.6c-13.67 27.82-9.251 62.23 13.91 85.39l117 117.1c14.62 14.5 38.21 14.5 52.71-.0016l52.75-52.75c14.5-14.5 14.5-38.08-.0016-52.71L384 278.6zM227.9 307L168.7 247.9l-148.9 148.9c-26.37 26.37-26.37 69.08 0 95.45C32.96 505.4 50.21 512 67.5 512s34.54-6.592 47.72-19.78l119.1-119.1C225.5 352.3 222.6 329.4 227.9 307zM64 472c-13.25 0-24-10.75-24-24c0-13.26 10.75-24 24-24S88 434.7 88 448C88 461.3 77.25 472 64 472z"
+    //       />
+    //     </svg>
+    //     <h1 class="mb-4 text-4xl font-bold leading-none tracking-tight text-gray-900 dark:text-white md:text-5xl lg:mb-6 xl:text-6xl">
+    //       Under Maintenance
+    //     </h1>
+    //     <p class="font-light text-gray-500 dark:text-gray-400 md:text-lg xl:text-xl">
+    //       Will be back up soon!
+    //     </p>
+    //   </div>
+    // </section>
+    <Router>
+      <Route path="/analytics" component={AnalyticsPage} />
+      <Route path="/chat" component={RagPage} />
+      <Route path="/about" component={AboutPage} />
+      <Route path="/help" component={HelpPage} />
+      <Route path="/" component={SearchPage} />
+      <Route path="*404" component={RedirectToSearch} />
+    </Router>
   ),
   root!,
 );


### PR DESCRIPTION
- **cleanup: move gitignore to top-level**
- **feature: add client for Trieve into server state data**
- **feature: finish pulling filters from query**
- **feature: finish making search API call**
- **feature: display search results**
- **styling: result divs and time_ago**
- **styling: website domain formatting**
- **feat: round score**
- **bugfix: search filter not working bc of /g syntax**
- **feat: add back post type select box**
- **feat: search by post type**
- **cleanup: minor bugfixes and form cleanup**
- **feat: sync filters with state + innerhtml for comments**
- **cleanup: make hybrid the default**
- **cleanup: use reqwest directly for search API call**
- **cleanup: make default search mode fulltext and make default page 1**
- **feature: add docker image**
- **feature: add close button to FullScreenModal**
- **feature: finish suggested queries on the client**
- **add under maintenance banner**
- **feature: add refresh to search suggestions**
