### PR TITLE
feat: labels for nojs in header and title and link to js version

### DIFF
--- a/actix-frontend/README.md
+++ b/actix-frontend/README.md
@@ -4,6 +4,16 @@
 
 `cargo watch -x run`
 
+Once it starts running, the initial logs will show you the address you can navigate to.
+Ex.
+```
+2024-08-29T19:55:48.838270Z  INFO actix_server::builder: starting 8 workers
+2024-08-29T19:55:48.838534Z  INFO actix_server::server: Actix runtime found; starting in Actix runtime
+2024-08-29T19:55:48.838612Z  INFO actix_server::server: starting service: "actix-web-service-0.0.0.0:9000", workers: 8, listening on: 0.0.0.0:9000
+```
+
+In this case, you can navigate to http://localhost:9000/
+
 ### Tailwind
 
 `npx tailwindcss -i ./static/in.css -o ./static/output.css --watch`

--- a/actix-frontend/src/templates/index.html
+++ b/actix-frontend/src/templates/index.html
@@ -33,7 +33,7 @@
       href="https://cdn.trieve.ai/favicon-16x16.png"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta property="og:title" content="Trieve HN Discovery" />
+    <meta property="og:title" content="Trieve HN Discovery (No JS)" />
     <meta
       property="og:site_name"
       content="Trieve discovery interface for Hacker News without any javascript"
@@ -48,7 +48,7 @@
     />
     <meta property="og:type" content="" />
     <meta property="og:image" content="https://cdn.trieve.ai/blog/trieve-hn-discovery/trieve-hn-discovery-preview-opengraph.webp" />
-    <title>Trieve HN Discovery</title>
+    <title>Trieve HN Discovery (No JS)</title>
     <link rel="stylesheet" href="/static/output.css" />
   </head>
 
@@ -69,7 +69,7 @@
                 class="h-[18px] w-[18px] border border-white"
             /></span>
             <div class="text-wrap">
-              <span class="mr-[5px] font-bold">Trieve HN Discovery</span>
+              <span class="mr-[5px] font-bold">Trieve HN Discovery (No JS)</span>
             </div>
           </a>
         </div>
@@ -80,6 +80,8 @@
             >About</a
           ><span class="pr-1">|</span
           ><a href="/help" class="pr-1 hover:text-white hover:underline">Help</a
+          ><span class="pr-1">|</span
+          ><a href="https://hn.trieve.ai/" class="pr-1 hover:text-white hover:underline">JS Version</a
           ><span class="pr-1">|</span
           ><a
             href="https://news.ycombinator.com/"


### PR DESCRIPTION
These small changes add labels marking this as No JS and a link to the JS Version.
Changes look like this:
<img width="924" alt="image" src="https://github.com/user-attachments/assets/1f21ddbd-79b1-418c-8d03-c91a03264462">



There are also small explanatory content added to the README.